### PR TITLE
Add copyright headers and scripts/copyright.sh

### DIFF
--- a/mcp_servers/__init__.py
+++ b/mcp_servers/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 """
 MCP Servers Package
 

--- a/mcp_servers/calendar/calendar_server.py
+++ b/mcp_servers/calendar/calendar_server.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
 import asyncio
 import json
 import uuid

--- a/mcp_servers/email/email_server.py
+++ b/mcp_servers/email/email_server.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
 import asyncio
 import json
 import uuid

--- a/mcp_servers/filestore/filestore_server.py
+++ b/mcp_servers/filestore/filestore_server.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
 import asyncio
 import json
 import uuid

--- a/mcp_servers/models.py
+++ b/mcp_servers/models.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 from datetime import datetime
 from enum import Enum
 from typing import Optional, List, Dict, Union

--- a/scripts/copyright.sh
+++ b/scripts/copyright.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# This script automates the process of adding a standard Microsoft copyright header
+# to source files in the repository.
+#
+# It applies the correct comment style for Python files (.py),
+# and targets all Python files in the project.
+#
+# The script is idempotent, meaning it won't add a header if one already exists.
+
+# This script adds a copyright notice to relevant source files in the repository
+# that do not already have it.
+
+# Copyright text for languages using # comments (Python)
+read -r -d '' COPYRIGHT_TEXT_HASH <<'EOF'
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+EOF
+
+CHECK_STRING_HASH=$(echo "$COPYRIGHT_TEXT_HASH" | head -n 1)
+
+# Use git ls-files to find all tracked and untracked relevant files.
+# This is better than `find` because it respects .gitignore.
+# We look for .py files everywhere.
+{ 
+    git ls-files -- '*.py'; 
+    git ls-files --others --exclude-standard -- '*.py';
+} | sort -u | while read -r file; do
+    # Ensure the file exists and is a regular file
+    if [ ! -f "$file" ]; then
+        continue
+    fi
+
+    COPYRIGHT_TEXT=""
+    CHECK_STRING=""
+
+    case "$file" in
+        *.py)
+            COPYRIGHT_TEXT="$COPYRIGHT_TEXT_HASH"
+            CHECK_STRING="$CHECK_STRING_HASH"
+            ;;
+        *)
+            continue
+            ;;
+    esac
+
+    # Check if the file already contains the copyright string. If so, skip.
+    if grep -qF "$CHECK_STRING" "$file"; then
+        continue
+    fi
+
+    echo "Adding copyright to $file"
+    
+    # Handle shebangs for script files
+    SHEBANG=""
+    FILE_CONTENT_PATH="$file"
+    if [[ "$file" == *.py ]] && head -n 1 "$file" | grep -q '^#!'; then
+        SHEBANG=$(head -n 1 "$file")
+        # Use a temporary file to strip the shebang for processing
+        TMP_NO_SHEBANG=$(mktemp)
+        tail -n +2 "$file" > "$TMP_NO_SHEBANG"
+        FILE_CONTENT_PATH="$TMP_NO_SHEBANG"
+    fi
+
+    # Prepend the copyright text to the file
+    TMPFILE=$(mktemp)
+
+    # Write shebang if it exists
+    if [ -n "$SHEBANG" ]; then
+        echo "$SHEBANG" > "$TMPFILE"
+        echo "" >> "$TMPFILE"
+    fi
+    
+    echo "$COPYRIGHT_TEXT" >> "$TMPFILE"
+    echo "" >> "$TMPFILE"
+    cat "$FILE_CONTENT_PATH" >> "$TMPFILE"
+    mv "$TMPFILE" "$file"
+
+    # Clean up temp file if created
+    if [ -n "$SHEBANG" ]; then
+        rm "$TMP_NO_SHEBANG"
+    fi
+done
+
+echo "Copyright check and update complete."

--- a/scripts/run_interpreter.py
+++ b/scripts/run_interpreter.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 """
 Run the P-LLM interpreter standalone for testing and debugging.
 """

--- a/scripts/test_visualizer.py
+++ b/scripts/test_visualizer.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
 import sys
 from pathlib import Path
 

--- a/src/dromedary/__init__.py
+++ b/src/dromedary/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 """Dromedary Agent System"""
 
 __version__ = "0.1.0" 

--- a/src/dromedary/agent.py
+++ b/src/dromedary/agent.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 import asyncio
 import os
 import sys

--- a/src/dromedary/executor.py
+++ b/src/dromedary/executor.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 import ast
 import operator
 from typing import Any, Dict, List, Union

--- a/src/dromedary/interpreter.py
+++ b/src/dromedary/interpreter.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 import ast
 import os
 from enum import Enum

--- a/src/dromedary/mcp/__init__.py
+++ b/src/dromedary/mcp/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 """
 Dromedary MCP - Model Context Protocol integration for the Dromedary system.
 """

--- a/src/dromedary/mcp/client.py
+++ b/src/dromedary/mcp/client.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 """
 MCP client management for connecting to and managing MCP servers.
 """

--- a/src/dromedary/mcp/manager.py
+++ b/src/dromedary/mcp/manager.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 """
 Manages a persistent, background-threaded connection to MCP servers.
 """

--- a/src/dromedary/mcp/tool_loader.py
+++ b/src/dromedary/mcp/tool_loader.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 """
 Provides a unified, high-level interface for accessing MCP tools.
 """

--- a/src/dromedary/mcp/tool_mapper.py
+++ b/src/dromedary/mcp/tool_mapper.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 """
 MCP tool mapper for converting MCP tools to Python callable functions.
 """

--- a/src/dromedary/mcp/types.py
+++ b/src/dromedary/mcp/types.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 """
 Type conversion utilities for MCP integration.
 """

--- a/src/dromedary/policy/__init__.py
+++ b/src/dromedary/policy/__init__.py
@@ -1,1 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 """Policy management for Dromedary""" 

--- a/src/dromedary/policy/engine.py
+++ b/src/dromedary/policy/engine.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 import os
 import yaml
 from typing import Dict, List, Any, Optional, Tuple

--- a/src/dromedary/policy/loader.py
+++ b/src/dromedary/policy/loader.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 from abc import ABC, abstractmethod
 from typing import Dict, List, Any, Optional
 from datetime import datetime

--- a/src/dromedary/prompt_builder.py
+++ b/src/dromedary/prompt_builder.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 import inspect
 from typing import get_type_hints, get_origin, get_args, Optional
 from langchain.tools import BaseTool

--- a/src/dromedary/provenance_graph.py
+++ b/src/dromedary/provenance_graph.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Tuple, Optional

--- a/src/dromedary/utils/__init__.py
+++ b/src/dromedary/utils/__init__.py
@@ -1,1 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 """Utility functions for Dromedary""" 

--- a/src/dromedary/utils/visualizer.py
+++ b/src/dromedary/utils/visualizer.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 import matplotlib
 
 # use interactive backend

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 """
 P-LLM Test Suite
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 import sys
 import os
 from pathlib import Path

--- a/tests/mcp/__init__.py
+++ b/tests/mcp/__init__.py
@@ -1,1 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 """Tests for MCP components""" 

--- a/tests/mcp/test_client.py
+++ b/tests/mcp/test_client.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 import asyncio
 import json
 import os

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
 import asyncio
 import json
 import subprocess

--- a/tests/mcp/test_types.py
+++ b/tests/mcp/test_types.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 import json
 import sys
 import os

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 import asyncio
 import tempfile
 import json

--- a/tests/test_interpreter_integration.py
+++ b/tests/test_interpreter_integration.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 import pytest
 from src.dromedary.interpreter import PythonInterpreter
 from src.dromedary.provenance_graph import SourceType, CapabilityValue

--- a/tests/test_policy_violation_integration.py
+++ b/tests/test_policy_violation_integration.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 import pytest
 import sys
 import os

--- a/tests/test_provenance_graph.py
+++ b/tests/test_provenance_graph.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 from src.dromedary.provenance_graph import ProvenanceGraph, Source, SourceType, ProvenanceTracker, CapabilityValue
 
 def test_add_literal_node():

--- a/tests/testdata/test1.py
+++ b/tests/testdata/test1.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 # Retrieve the most recently received email
 received = get_received_emails()
 last_email = received[-1]

--- a/tests/testdata/test2.py
+++ b/tests/testdata/test2.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 from datetime import date, timedelta                                                      
 from pydantic import BaseModel, EmailStr                                                  
 # 1. Fetch the most recent received email                                                 


### PR DESCRIPTION
This PR adds the standard copyright header to all source files per the script I've committed to scripts/copyright.sh:

```
# This script automates the process of adding a standard Microsoft copyright header
# to source files in the repository.
#
# It applies the correct comment style for Python files (.py),
# and targets all Python files in the project.
#
# The script is idempotent, meaning it won't add a header if one already exists.

# This script adds a copyright notice to relevant source files in the repository
# that do not already have it.
```